### PR TITLE
Add a new filter to avoid using events with event start property lower than 2017-01-01. CVP-119

### DIFF
--- a/assets/bigquery/vessels-vessel-info.sql.j2
+++ b/assets/bigquery/vessels-vessel-info.sql.j2
@@ -8,12 +8,14 @@ WITH
   SELECT
     *
   FROM
-    `{{ encounter_events }}` ),
+    `{{ encounter_events }}`
+  WHERE event_start >= '2017-01-01' ),
   source_published_events_loitering AS (
   SELECT
     *
   FROM
-    `{{ loitering_events }}` ),
+    `{{ loitering_events }}`
+  WHERE event_start >= '2017-01-01' ),
   source_vessel_info AS (
   SELECT
     *


### PR DESCRIPTION
When the `pipe-carrier-portal`updates the vessel, the process gets all events to populate the vessel info. This generates a problem because the CVP doesn't show events before 2017-01-01.

I've added a filter to avoid using events started before 2017-01-01. 